### PR TITLE
Fixes Missing/invalid DB name error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,9 @@ function loadString(db, data, opts, callback) {
 
     return db.info();
   }).then(function (info) {
+    if (!opts.proxy) {
+      return;
+    }
     var src = new db.constructor(opts.proxy,
       utils.extend(true, {}, {}, opts));
     var target = new db.constructor(info.db_name,


### PR DESCRIPTION
This PR fixes #38 in which the error is being thrown: Missing/invalid DB name

Because of where this error is thrown, I don't think there is a way to catch this in the tests, so I did not modify the tests.