### PR TITLE
convert plain array attachments to blobs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,17 @@ function parseDump(data) {
       }
       line = JSON.parse(line);
       if (line.docs) {
+        // convert plain array attachments to blobs
+        line.docs.forEach(function (doc) {
+          if(doc._attachments) {
+            for(var id in doc._attachments) {
+              var att = doc._attachments[id];
+              if(att.data && Array.isArray(att.data.data)) {
+                doc._attachments[id].data = new Blob([new Uint8Array(att.data.data)], {type : att.content_type});
+              }
+            }
+          }
+        });
         docs = docs.concat(line.docs);
       }
       if (line.seq) {


### PR DESCRIPTION
to prevent errors on calculate md5